### PR TITLE
Improve compat with v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-json-validator",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -422,6 +422,22 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -469,6 +485,23 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -513,6 +546,18 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.3.tgz",
+      "integrity": "sha512-opgSsy+cEF9N8MgaVPnWVtdJ3o4mV2aMHvDq7thkQUFt0EuOHJon4rQpJfhjmNHB+ikl0Cd6WhWIErOyQ+f7tw==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -667,6 +712,48 @@
         "tslib": "^1.9.3"
       }
     },
+    "ansi-align": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "ansi-escapes": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
@@ -734,6 +821,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -753,6 +846,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
@@ -934,6 +1033,60 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "boxen": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1049,6 +1202,12 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -1087,6 +1246,25 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "map-obj": "^2.0.0",
+        "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -1095,6 +1273,12 @@
       "requires": {
         "rsvp": "^4.8.4"
       }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -1186,6 +1370,12 @@
           }
         }
       }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -1302,6 +1492,31 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "configstore": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        }
+      }
+    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -1353,6 +1568,15 @@
         }
       }
     },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1374,6 +1598,12 @@
         }
       }
     },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
@@ -1387,6 +1617,15 @@
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
       }
     },
     "dashdash": {
@@ -1443,6 +1682,24 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -1453,6 +1710,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -1535,6 +1798,15 @@
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
+    "dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
+      "requires": {
+        "path-type": "^3.0.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1552,6 +1824,21 @@
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -1728,6 +2015,58 @@
       "resolved": "https://registry.npmjs.org/eslint-config-typescript/-/eslint-config-typescript-3.0.0.tgz",
       "integrity": "sha512-CwC2cQ29OLE1OUw0k+Twpc6wpCdenG8rrErl89sWrzmMpWfkulyeQS1HJhhjU0B3Tb4k41zdei4LtX26x5m60Q==",
       "dev": true
+    },
+    "eslint-formatter-pretty": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
+      "integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^2.0.0",
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.0.0",
+        "plur": "^2.1.2",
+        "string-width": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "eslint-plugin-prettier": {
       "version": "3.1.1",
@@ -2029,6 +2368,43 @@
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        }
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2798,6 +3174,21 @@
         "is-glob": "^4.0.1"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -2821,6 +3212,33 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
       }
@@ -3013,6 +3431,12 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -3027,6 +3451,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
     "indexes-of": {
@@ -3049,6 +3479,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -3080,6 +3516,12 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3240,6 +3682,22 @@
       "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
       "dev": true
     },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -3258,6 +3716,21 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -3281,6 +3754,12 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -3289,6 +3768,12 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4017,6 +4502,15 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "latest-version": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
+      "requires": {
+        "package-json": "^4.0.0"
+      }
+    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -4103,6 +4597,15 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4111,6 +4614,22 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -4176,6 +4695,12 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
+    "map-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -4202,10 +4727,103 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "meow": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^4.0.0",
+        "decamelize-keys": "^1.0.0",
+        "loud-rejection": "^1.0.0",
+        "minimist-options": "^3.0.1",
+        "normalize-package-data": "^2.3.4",
+        "read-pkg-up": "^3.0.0",
+        "redent": "^2.0.0",
+        "trim-newlines": "^2.0.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
       "dev": true
     },
     "micromatch": {
@@ -4264,6 +4882,16 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0"
+      }
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -4630,6 +5258,26 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "package-json": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
+      "requires": {
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4680,6 +5328,12 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -4690,6 +5344,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -4756,6 +5416,15 @@
       "dev": true,
       "requires": {
         "find-up": "^3.0.0"
+      }
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^1.0.0"
       }
     },
     "pn": {
@@ -4919,6 +5588,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "prettier": {
@@ -5099,6 +5774,38 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
+    },
     "react-is": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
@@ -5135,6 +5842,16 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "redent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^3.0.0",
+        "strip-indent": "^2.0.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
@@ -5165,6 +5882,25 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "registry-auth-token": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.0.1"
+      }
     },
     "remark-math": {
       "version": "1.0.6",
@@ -5444,6 +6180,23 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -5889,6 +6642,18 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -5947,6 +6712,49 @@
         }
       }
     },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -5975,6 +6783,12 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
     "tmp": {
@@ -6065,6 +6879,12 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
     },
+    "trim-newlines": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+      "dev": true
+    },
     "trim-trailing-lines": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
@@ -6114,6 +6934,133 @@
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
+    "tsd": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.10.0.tgz",
+      "integrity": "sha512-Gj/GoGBoskUJHZnja8V936sMAs3daHjZDQCqYQWMWEm4kNZLzYHvAAdV+apeg3mjsxMmvt8FByOM1AnYDdo+6g==",
+      "dev": true,
+      "requires": {
+        "eslint-formatter-pretty": "^1.3.0",
+        "execa": "^2.0.4",
+        "globby": "^9.1.0",
+        "meow": "^5.0.0",
+        "path-exists": "^3.0.0",
+        "read-pkg-up": "^4.0.0",
+        "update-notifier": "^2.5.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+          "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^1.0.2",
+            "dir-glob": "^2.2.2",
+            "fast-glob": "^2.2.6",
+            "glob": "^7.1.3",
+            "ignore": "^4.0.3",
+            "pify": "^4.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+          "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -6270,6 +7217,15 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
     "unist-util-is": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
@@ -6349,6 +7305,47 @@
         }
       }
     },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+      "dev": true,
+      "requires": {
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          }
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -6362,6 +7359,15 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
     },
     "use": {
       "version": "3.1.1",
@@ -6532,6 +7538,48 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -6619,6 +7667,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jest": "^24.9.0",
     "prettier": "github:prettier/prettier",
     "ts-jest": "^24.1.0",
+    "tsd": "^0.10.0",
     "tslint": "^5.20.0",
     "typescript": "^3.7.1-rc"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Schema } from "./json-schema";
+import { createSchema } from "./json-schema";
 import { TsjsonParser, Validated } from "./tsjson-parser";
 
-export { Schema, TsjsonParser, Validated };
+export { createSchema, TsjsonParser, Validated };

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -1,27 +1,28 @@
-import { SchemaValidateFunction } from "ajv";
-
 // A Typescript interpretation of the JSON spec from
 // http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
 
-// ENFORCED indicates that the field is enforced by the type system, and it should be
-// impossible for any type assignable to Validated<schema> to fail JSON validation because of constraints
-// that this field introduces.
-// For example, the `required` field on objects is ENFORCED because a type assignable to Validated<T>
-// must have all fields marked `required`.
+// ENFORCED (💪) indicates that the field is enforced by the type system, and it should be impossible for any type
+// assignable to T to fail JSON validation because of constraints that this field introduces.
+// For example, the required field on objects is ENFORCED because a type assignable to T is guaranteed to contain all
+// fields marked required.
 
-// PARTIALLY ENFORCED indicates that the field is partially enforced by the type system, but it may be possible
-// to assign a type to Validated<schema> that does not validate.
-// For example, arrays with the additionalItems parameter are PARTIALLY ENFORCED becuase (currently) every element
-// in the validated type can be assigned to the additionalItems type, when only items after items.length should
-// be validated against this schema.
+// PARTIALLY ENFORCED (🔓) indicates that the field is partially enforced by the type system, but it may be possible
+// to assign a type to T that fails validation against s.
+// For example, arrays with the additionalItems parameter are PARTIALLY ENFORCED becuase (currently) every element in
+// the validated type can be assigned to the additionalItems type, when only items after items.length should be
+// validated against this schema.
 
-// NOT ENFORCED indicates that the field is not enforced by the type system. This is either because it's impossible
-// to do so efficiently given Typescript, or because I haven't figured out how yet. If the latter, hopefully I've
-// included a comment.
-// For example, the `pattern` constraint in a string type is NOT ENFORCED because there's no reasonable way to
-// express a type that means "a string that matches this regex".
+// NOT ENFORCED (⚠️) indicates that the field is not enforced by the type system. This is either because it's
+// impossible to do so efficiently given Typescript, or because I haven't figured out how yet.
+// If the latter, hopefully I've included a comment.
 
-// NO ENFORCEMENT NEEDED means that this field does not add any constraints to a JSON schema so is essentially a comment.
+// For example, the pattern constraint in a string type is NOT ENFORCED because there's no reasonable way to express a
+// type that means "a string that matches this regex".
+
+// NO ENFORCEMENT NEEDED (🤷) (means that this field does not add any constraints to a JSON schema so is essentially a
+// comment.
+
+// NOT SUPPORTED (❌) means you can't currently define a TsjsonSchema that includes this validation keyword :(
 
 // Symbol needed to compile a program that passes typechecking but still fails schema validation.
 export const InternalTypeSymbol = Symbol("InternalType");
@@ -47,249 +48,9 @@ type UnionToIntersection<U> = (U extends any
   ? I
   : never;
 
-interface BaseJsonSchema {
-  title?: string; // NO ENFORCEMENT NEEDED
-  description?: string; // NO ENFORCEMENT NEEDED
-}
-
-// The useful options assignable to a schema with {"type": "string"}
-interface StringOptions<EnumType extends string | undefined = undefined>
-  extends BaseJsonSchema {
-  enum?: readonly EnumType[]; // ENFORCED
-  format?: string; // NOT ENFORCED
-  maxLength?: string; // NOT ENFORCED
-  minLength?: string; // NOT ENFORCED
-  pattern?: string; // NOT ENFORCED
-}
-
-/**
- * Create a schema that validates strings.
- *
- * If the `enum` property is specified, it will by typed as a union of these enum values.
- * @param options
- */
-const stringConstructor = <T extends string>(
-  options: StringOptions<T> = {}
-) => {
-  type internalType = typeof options.enum extends undefined ? string : T;
-  return {
-    type: "string" as const,
-    ...options,
-    [InternalTypeSymbol]: {} as internalType
-  };
-};
-
-interface NumberOptions extends BaseJsonSchema {
-  multipleOf?: number; // NOT ENFORCED
-  minimum?: number; // NOT ENFORCED
-  exclusiveMinimum?: number; // NOT ENFORCED
-  maximum?: number; // NOT ENFORCED
-  exclusiveMaximum?: number; // NOT ENFORCED
-  description?: string; // NO ENFORCEMENT NEEDED
-}
-
-/**
- * Create a schema that validates numbers.
- *
- * @param options
- */
-const numberConstructor = (options: NumberOptions = {}) => {
-  return {
-    type: "number" as const,
-    ...options,
-    [InternalTypeSymbol]: {} as number
-  };
-};
-
-/**
- * Create a schema that validates integers.
- *
- * @param options
- */
-const integerConstructor = (options: NumberOptions = {}) => {
-  return {
-    type: "integer" as const,
-    ...options,
-    [InternalTypeSymbol]: {} as number
-  };
-};
-
-interface ObjectOptions<
-  Properties extends { [k: string]: JsonSchema },
-  AdditionalProperties extends JsonSchema,
-  RequiredProperties extends readonly (keyof Properties)[]
-> extends BaseJsonSchema {
-  properties?: Properties; // ENFORCED
-  additionalProperties?: AdditionalProperties; // ENFORCED
-  required: RequiredProperties; // ENFORCED; mandatory for now, since leaving it empty is making all properties required
-  propertyNames?: JsonSchema; // NOT ENFORCED; could get to PARTIALLY ENFORCED if we support enums here, but no better.
-  minProperties?: number; // NOT ENFORCED
-  maxProperties?: number; // NOT ENFORCED
-  // dependencies?: any; // not yet supported
-  patternProperties?: { [k: string]: JsonSchema }; // NOT ENFORCED
-}
-
-/**
- * Create a schema that validates objects.
- *
- * The `properties` field defines the keys and schemas that these properties must conform to.
- * `requiredProperties` marks zero or more fields required.
- * `additionalProperties` marks the types of the fields not specified in properties.
- * @param options
- */
-const objectConstructor = <
-  Properties extends { [k: string]: JsonSchema },
-  AdditionalProperties extends JsonSchema,
-  RequiredProperties extends readonly (keyof Properties)[]
->(
-  options: ObjectOptions<Properties, AdditionalProperties, RequiredProperties>
-) => {
-  type internalPropertyTypes = PartialRequire<
-    Partial<
-      // optional by default, unless explicitly in the required list
-      { [P in keyof Properties]: Properties[P][typeof InternalTypeSymbol] }
-    >,
-    RequiredProperties[number]
-  >;
-  type additionalPropertyTypes = { [k: string]: AdditionalProperties };
-  return {
-    type: "object" as const,
-    ...options,
-    [InternalTypeSymbol]: {} as internalPropertyTypes & additionalPropertyTypes
-  };
-};
-
-interface ArrayOptions<
-  Items extends JsonSchema | readonly JsonSchema[],
-  AdditionalItems extends Items extends JsonSchema // additionalItems doesn't make sense unless Items is a list
-    ? never
-    : JsonSchema
-> extends BaseJsonSchema {
-  items?: Items; // PARTIALLY ENFORCED; ENFORCED if it's a single schema but only PARTIALLY ENFORCED if it's a list of schemas
-  additionalItems?: AdditionalItems; // PARTIALLY ENFORCED; same reason as above
-  minItems?: number; // NOT ENFORCED
-  maxItems?: number; // NOT ENFORCED
-  uniqueItems?: boolean; // NOT ENFORCED
-}
-
-/**
- * Create a schema that validates arrays.
- *
- * The type of the array is defined by the `items` parameter, which is either
- * a single JSON schema or a list of JSON schemas. If `items` is a single schema,
- * all members of the array must conform to that schema. If it's a list of schemas,
- * each member of the array must validate to its respective schema, and all remaining
- * members must validate to the schema in AdditionalItems.
- * @param options
- */
-const arrayConstructor = <
-  Items extends JsonSchema | readonly JsonSchema[],
-  AdditionalItems extends Items extends JsonSchema ? never : JsonSchema
->(
-  options: ArrayOptions<Items, AdditionalItems> = {}
-) => {
-  type internalType = Items extends readonly JsonSchema[]
-    ? Array<
-        | Items[number][typeof InternalTypeSymbol]
-        | AdditionalItems[typeof InternalTypeSymbol]
-      > // this isn't strict enough, but I'm not sure if it's possible to improve this at the moment. Would be nicer to somehow concatenate the types, as in [exploded Items, ...AdditionalItems]
-    : Items extends JsonSchema // not sure why this isn't inferred
-    ? Items[typeof InternalTypeSymbol][]
-    : never;
-  return {
-    type: "array" as const,
-    ...options,
-    [InternalTypeSymbol]: {} as internalType
-  };
-};
-
-interface BooleanOptions extends BaseJsonSchema {}
-
-/**
- * Create a schema that validates boolean values.
- *
- * @param options
- */
-const booleanConstructor = (options: BooleanOptions = {}) => {
-  return {
-    type: "boolean" as const,
-    ...options,
-    [InternalTypeSymbol]: {} as boolean
-  };
-};
-
-interface NullOptions extends BaseJsonSchema {}
-
-/**
- * Create a schema that validates null values.
- *
- * @param options
- */
-const nullConstructor = (options: NullOptions = {}) => {
-  return {
-    type: "null" as const,
-    ...options,
-    [InternalTypeSymbol]: ({} as unknown) as null
-  };
-};
-
-interface AnyOfOptions<Schemas extends readonly JsonSchema[]>
-  extends BaseJsonSchema {
-  anyOf: Schemas; // ENFORCED
-}
-
-/**
- * Create a schema that validates if any schemas in its anyOf parameter validate.
- *
- * @param options
- */
-const anyOfConstructor = <Schemas extends readonly JsonSchema[]>(
-  options: AnyOfOptions<Schemas>
-) => {
-  return {
-    ...options,
-    [InternalTypeSymbol]: {} as typeof options.anyOf[number][typeof InternalTypeSymbol]
-  };
-};
-
-interface AllOfOptions<Schemas extends readonly JsonSchema[]>
-  extends BaseJsonSchema {
-  allOf: Schemas; // ENFORCED
-}
-
-/**
- * Create a schema that validates if all schemas in its allOf parameter validate.
- *
- * @param options
- */
-const allOfConstructor = <Schemas extends readonly JsonSchema[]>(
-  options: AllOfOptions<Schemas>
-) => {
-  return {
-    ...options,
-    [InternalTypeSymbol]: {} as UnionToIntersection<
-      typeof options.allOf[number][typeof InternalTypeSymbol]
-    >
-  };
-};
-
-export interface InterfaceWithHiddenType {
+export interface SchemaLike {
   [InternalTypeSymbol]: unknown;
 }
-
-export interface JsonSchema extends InterfaceWithHiddenType {}
-
-export const Schema = {
-  String: stringConstructor,
-  Number: numberConstructor,
-  Integer: integerConstructor,
-  Object: objectConstructor,
-  Array: arrayConstructor,
-  Boolean: booleanConstructor,
-  Null: nullConstructor,
-  AnyOf: anyOfConstructor,
-  AllOf: allOfConstructor
-};
 
 type SimpleType =
   | "array"
@@ -300,109 +61,206 @@ type SimpleType =
   | "object"
   | "string";
 
+// If a const field is specified, then the value must be exactly that type.
+// Otherwise, it can be any valid JSON value.
 type ConstConstraint<
   Const extends JsonValue | undefined
-> = Const extends JsonValue ? Const : unknown;
+> = Const extends JsonValue ? Const : unknown; // Could possibly replace all these unknows with JsonValues, but it makes the derived types annoying.
 
-// type NotConstraint<Not extends JsonSchema | undefined> = Not extends JsonSchema ?
+type SimpleTypeConstraint<
+  Type extends SimpleType | undefined
+> = Type extends "array"
+  ? Array<JsonValue>
+  : Type extends "boolean"
+  ? boolean
+  : Type extends "integer" | "number"
+  ? number
+  : Type extends "null"
+  ? null
+  : Type extends "object"
+  ? { [k: string]: unknown }
+  : Type extends "string"
+  ? string
+  : unknown;
+
+type EnumConstraint<
+  Enum extends readonly JsonValue[] | undefined
+> = Enum extends readonly JsonValue[] ? Enum[number] : unknown;
+
+// optional by default, unless explicitly in the required list
+type PropertiesConstraint<
+  Properties extends { [k: string]: SchemaLike } | undefined,
+  Required extends readonly (keyof Properties)[] | undefined
+> = Properties extends { [k: string]: SchemaLike }
+  ? Required extends readonly (keyof Properties)[]
+    ? PartialRequire<
+        Partial<
+          { [P in keyof Properties]: Properties[P][typeof InternalTypeSymbol] }
+        >,
+        Required[number]
+      >
+    : Partial<
+        // optional by default, unless explicitly in the required list
+        { [P in keyof Properties]: Properties[P][typeof InternalTypeSymbol] }
+      >
+  : unknown;
+
+type AdditionalPropertiesConstraint<
+  AdditionalProperties extends SchemaLike | undefined
+> = AdditionalProperties extends SchemaLike
+  ? { [k: string]: AdditionalProperties[typeof InternalTypeSymbol] }
+  : unknown;
+
+// if items is a schema, then every element conforms to it.
+// If items is a list, then either additionalItems is supplied, in which case every element is either one of items[number] or additionalItems
+// or additionalItems is not supplied, in which case we just get the union of all item types.
+// These isn't strict enough; instead of Items[number], it would be better to have [...Items, *AdditionalItems]
+// since when items are specified in a list, ordering is important.
+type ItemsConstraint<
+  Items extends (SchemaLike | readonly SchemaLike[]) | undefined,
+  AdditionalItems extends SchemaLike | undefined
+> = Items extends SchemaLike
+  ? Array<Items[typeof InternalTypeSymbol]>
+  : Items extends readonly SchemaLike[]
+  ? AdditionalItems extends SchemaLike //
+    ? Array<
+        | Items[number][typeof InternalTypeSymbol]
+        | AdditionalItems[typeof InternalTypeSymbol]
+      >
+    : Array<Items[number][typeof InternalTypeSymbol]>
+  : unknown;
+
+type AllOfConstraint<
+  AllOf extends readonly SchemaLike[] | undefined
+> = AllOf extends readonly SchemaLike[]
+  ? UnionToIntersection<AllOf[number][typeof InternalTypeSymbol]>
+  : unknown;
+
+type AnyOfConstraint<
+  AnyOf extends readonly SchemaLike[] | undefined
+> = AnyOf extends readonly SchemaLike[]
+  ? AnyOf[number][typeof InternalTypeSymbol]
+  : unknown;
+
+// This isn't strict enough; should be XOR instead of Or
+type OneOfConstraint<
+  OneOf extends readonly SchemaLike[] | undefined
+> = AnyOfConstraint<OneOf>;
+
+// If both `then` and `else` are specified, then we know that the type must be either Then or Else.
+// If only one or 0 are specified, we don't know which one the `if` matched, so we don't add any constraints.
+type IfThenElseConstraint<
+  Then extends SchemaLike | undefined,
+  Else extends SchemaLike | undefined
+> = Then extends SchemaLike
+  ? Else extends SchemaLike
+    ? Then[typeof InternalTypeSymbol] | Else[typeof InternalTypeSymbol]
+    : unknown
+  : unknown;
 
 // Make it impossible to define an invalid schema, and also impossible to define a schema that just doesn't make sense
 // (e.g. no reason to have a minimum constraint on a string.)
 interface Schema<
-  Type extends SimpleType | readonly SimpleType[] | undefined = undefined, // type can be either a single type or a list of types (TODO allow it to be a list of types)
-  Properties extends { [k: string]: JsonSchema } | undefined = undefined,
-  Items extends (JsonSchema | readonly JsonSchema[]) | undefined = undefined,
-  AdditionalItems extends JsonSchema | undefined = undefined,
-  AdditionalProperties extends JsonSchema | undefined = undefined,
+  Type extends SimpleType | undefined = undefined, // type can be either a single type or a list of types (TODO allow it to be a list of types) (| readonly SimpleType[])
+  Properties extends { [k: string]: SchemaLike } | undefined = undefined,
+  Items extends (SchemaLike | readonly SchemaLike[]) | undefined = undefined,
+  AdditionalItems extends SchemaLike | undefined = undefined,
+  AdditionalProperties extends SchemaLike | undefined = undefined,
   Required extends readonly (keyof Properties)[] | undefined = undefined,
-  Const extends JsonValue | undefined = undefined, // TODO constrain to type
-  Enum extends readonly JsonValue[] | undefined = undefined, // TODO constrain to type
-  AllOf extends readonly JsonSchema[] | undefined = undefined,
-  AnyOf extends readonly JsonSchema[] | undefined = undefined,
-  OneOf extends readonly JsonSchema[] | undefined = undefined,
-  Not extends JsonSchema | undefined = undefined,
-  CalculatedType = unknown // where the magic happens
+  Const extends JsonValue | undefined = undefined,
+  Enum extends readonly JsonValue[] | undefined = undefined,
+  AllOf extends readonly SchemaLike[] | undefined = undefined,
+  AnyOf extends readonly SchemaLike[] | undefined = undefined,
+  OneOf extends readonly SchemaLike[] | undefined = undefined,
+  Not extends SchemaLike | undefined = undefined, // not yet enforced
+  If extends SchemaLike | undefined = undefined,
+  Then extends SchemaLike | undefined = undefined,
+  Else extends SchemaLike | undefined = undefined,
+  CalculatedType = ConstConstraint<Const> &
+    SimpleTypeConstraint<Type> &
+    EnumConstraint<Enum> &
+    PropertiesConstraint<Properties, Required> &
+    AdditionalPropertiesConstraint<AdditionalProperties> &
+    ItemsConstraint<Items, AdditionalItems> &
+    AllOfConstraint<AllOf> &
+    AnyOfConstraint<AnyOf> &
+    OneOfConstraint<OneOf> &
+    IfThenElseConstraint<Then, Else>
 > {
-  $id?: string; // adds no constraints, can be in any schema
-  $schema?: "http://json-schema.org/draft-07/schema#"; // if you want to specify the schema, it's got to be draft-07 right now!
+  $id?: string; // 🤷 adds no constraints, can be in any schema.
+  $schema?: "http://json-schema.org/draft-07/schema#"; // 🤷 if you want to specify the schema, it's got to be draft-07 right now!
   // $ref?: string; // not yet supported
-  $comment?: string; // adds no constraints, can be in any schema
-  title?: string; // adds no constraints, can be in any schema
-  description?: string; // adds no constraints, can be in any schema
-  default?: CalculatedType;
-  readOnly?: boolean;
-  examples?: JsonValue[];
-  multipleOf?: Type extends "number" | "integer" ? number : never; // only makes sense for number/integer types
-  maximum?: Type extends "number" | "integer" ? number : never; // only makes sense for number/integer types
-  exclusiveMaximum?: Type extends "number" | "integer" ? number : never; // only makes sense for number/integer types
-  minimum?: Type extends "number" | "integer" ? number : never; // only makes sense for number/integer types
-  exclusiveMinimum?: Type extends "number" | "integer" ? number : never; // only makes sense for number/integer types
-  minLength?: Type extends "string" ? number : never; // only makes sense for string types
-  maxLength?: Type extends "string" ? number : never; // only makes sense for string types
-  pattern?: Type extends "string" ? string : never; // only makes sense for string types
-  additionalItems?: Type extends "array" // only makes sense for array types
-    ? Items extends JsonSchema // where the items field is not a single schema
+  $comment?: string; // 🤷 adds no constraints, can be in any schema
+  title?: string; // 🤷 adds no constraints, can be in any schema
+  description?: string; // 🤷 adds no constraints, can be in any schema
+  default?: CalculatedType; // 💪 Can only be assigned types that the rest of the schema validates
+  readOnly?: boolean; // 🤷
+  examples?: JsonValue[]; // 🤷
+  multipleOf?: Type extends "number" | "integer" ? number : never; // ⚠️ only makes sense for number/integer types
+  maximum?: Type extends "number" | "integer" ? number : never; // ⚠️ only makes sense for number/integer types
+  exclusiveMaximum?: Type extends "number" | "integer" ? number : never; // ⚠️ only makes sense for number/integer types
+  minimum?: Type extends "number" | "integer" ? number : never; // ⚠️ only makes sense for number/integer types
+  exclusiveMinimum?: Type extends "number" | "integer" ? number : never; // ⚠️ only makes sense for number/integer types
+  minLength?: Type extends "string" ? number : never; // ⚠️ only makes sense for string types
+  maxLength?: Type extends "string" ? number : never; // ⚠️ only makes sense for string types
+  pattern?: Type extends "string" ? string : never; // ⚠️ only makes sense for string types
+  additionalItems?: Type extends "array" // 🔓 only makes sense for array types
+    ? Items extends SchemaLike // where the items field is not a single schema
       ? never
       : AdditionalItems
     : never;
-  items?: Type extends "array" ? Items : never; // only makes sense for array types
-  maxItems?: Type extends "array" ? number : never; // only makes sense for array types
-  minItems?: Type extends "array" ? number : never; // only makes sense for array types
-  uniqueItems?: Type extends "array" ? boolean : never; // only makes sense for array types
-  contains?: Type extends "array" ? Schema : never; // only makes sense for array types
-  maxProperties?: Type extends "object" ? number : never; // only makes sense for object types
-  minProperties?: Type extends "object" ? number : never; // only makes sense for object types
-  required?: Type extends "object" ? Required : never; // only makes sense for object types
-  additionalProperties?: Type extends "object" ? AdditionalProperties : never; // only makes sense for object types
-  // definitions?: TODO
-  properties?: Type extends "object" ? Properties : never; // only makes sense for object types
-  patternProperties?: Type extends "object" ? { [k: string]: Schema } : never; // only makes sense for object types
-  // dependencies?: TODO
-  propertyNames?: Type extends "object" ? Schema : never; // only makes sense for object types
-  const?: Const;
-  enum?: Enum;
-  type?: Type;
-  format?: Type extends "string" ? string : never; // only makes sense for string types
-  contentMediaType?: Type extends "string" ? string : never;
-  contentEncoding?: Type extends "string" ? string : never;
-  // if?: Schema; // not yet supported
-  // then?: Schema; // not yet supported
-  // else?: Schema; // not yet supported
-  allOf?: AllOf;
-  anyOf?: AnyOf;
-  oneOf?: OneOf;
-  not?: Not;
+  items?: Type extends "array" ? Items : never; // 🔓 only makes sense for array types
+  maxItems?: Type extends "array" ? number : never; // ⚠️ only makes sense for array types
+  minItems?: Type extends "array" ? number : never; // ⚠️ only makes sense for array types
+  uniqueItems?: Type extends "array" ? boolean : never; // ⚠️ only makes sense for array types
+  contains?: Type extends "array" ? SchemaLike : never; // ⚠️ only makes sense for array types
+  maxProperties?: Type extends "object" ? number : never; // ⚠️ only makes sense for object types
+  minProperties?: Type extends "object" ? number : never; // ⚠️ only makes sense for object types
+  required?: Type extends "object" ? Required : never; // 💪 only makes sense for object types
+  additionalProperties?: Type extends "object" ? AdditionalProperties : never; // 💪 only makes sense for object types
+  // definitions?: // not yet supported
+  properties?: Type extends "object" ? Properties : never; // 💪 only makes sense for object types
+  patternProperties?: Type extends "object"
+    ? { [k: string]: SchemaLike }
+    : never; // ⚠️ only makes sense for object types
+  // dependencies?: // not yet supported
+  propertyNames?: Type extends "object" ? SchemaLike : never; // ⚠️ only makes sense for object types
+  const?: Const; // 💪
+  enum?: Enum; // 💪
+  type?: Type; // 💪
+  format?: Type extends "string" ? string : never; // ⚠️ only makes sense for string types
+  contentMediaType?: Type extends "string" ? string : never; // 🤷
+  contentEncoding?: Type extends "string" ? string : never; // 🤷
+  if?: Then extends SchemaLike // 🤷
+    ? SchemaLike
+    : Else extends SchemaLike
+    ? SchemaLike
+    : never; // If `if` is specified, then at least one of `then` or `else` should be specified.
+  then?: If extends SchemaLike ? SchemaLike : never; // 💪 Only matters if `if` is supplied
+  else?: If extends SchemaLike ? SchemaLike : never; // 💪 Only matters if `if` is supplied
+  allOf?: AllOf; // 💪
+  anyOf?: AnyOf; // 💪
+  oneOf?: OneOf; // 🔓
+  not?: Not; // ⚠️
   [InternalTypeSymbol]?: CalculatedType;
 }
 
-const createSchema = <
-  Type extends SimpleType | undefined = undefined, // type can be either a single type or a list of types // TODO support type as SimpleType[]
-  Properties extends
-    | (Type extends "object" ? { [k: string]: JsonSchema } : never) // properties only makes sense if type is object
-    | undefined = undefined,
-  Items extends  // items only makes sense if type is "array"
-    | (Type extends "array" ? JsonSchema | readonly JsonSchema[] : never)
-    | undefined = undefined,
-  AdditionalItems extends
-    | (Type extends "array" // additionalItems only makes sense if type is array
-        ? Items extends JsonSchema // and if Items is a list of schemas, not a single schema
-          ? never
-          : JsonSchema
-        : never)
-    | undefined = undefined,
-  AdditionalProperties extends
-    | (Type extends "object" ? JsonSchema : never) // additionalProperties only makes sense if type is object
-    | undefined = undefined,
-  Required extends
-    | (Type extends "object" ? readonly (keyof Properties)[] : never) // required only makes sense if type is object
-    | undefined = undefined,
-  Const extends JsonValue | undefined = undefined, // TODO constrain to type
-  Enum extends readonly JsonValue[] | undefined = undefined, // TODO constrain to type
-  AllOf extends readonly JsonSchema[] | undefined = undefined,
-  AnyOf extends readonly JsonSchema[] | undefined = undefined,
-  OneOf extends readonly JsonSchema[] | undefined = undefined,
-  Not extends JsonSchema | undefined = undefined
-  // below here we just constrain to say "You shouldn't create a schema with a "
+export const createSchema = <
+  Type extends SimpleType | undefined = undefined,
+  Properties extends { [k: string]: SchemaLike } | undefined = undefined,
+  Items extends (SchemaLike | readonly SchemaLike[]) | undefined = undefined,
+  AdditionalItems extends SchemaLike | undefined = undefined,
+  AdditionalProperties extends SchemaLike | undefined = undefined,
+  Required extends readonly (keyof Properties)[] | undefined = undefined,
+  Const extends JsonValue | undefined = undefined,
+  Enum extends readonly JsonValue[] | undefined = undefined,
+  AllOf extends readonly SchemaLike[] | undefined = undefined,
+  AnyOf extends readonly SchemaLike[] | undefined = undefined,
+  OneOf extends readonly SchemaLike[] | undefined = undefined,
+  Not extends SchemaLike | undefined = undefined,
+  If extends SchemaLike | undefined = undefined,
+  Then extends SchemaLike | undefined = undefined,
+  Else extends SchemaLike | undefined = undefined
 >(
   schema: Schema<
     Type,
@@ -416,12 +274,19 @@ const createSchema = <
     AllOf,
     AnyOf,
     OneOf,
-    Not
+    Not,
+    If,
+    Then,
+    Else
   >
-) => {
-  type internalType = string;
-  return {
-    ...schema,
-    [InternalTypeSymbol]: {} as internalType
+) =>
+  // require the InternalTypeSymbol here so we can't pass illegitimate schemas into
+  // the tsjsonParser class.
+  {
+    return {
+      ...schema,
+      [InternalTypeSymbol]: {} as NonNullable<
+        typeof schema[typeof InternalTypeSymbol]
+      >
+    };
   };
-};

--- a/src/tsjson-parser.ts
+++ b/src/tsjson-parser.ts
@@ -1,6 +1,6 @@
 import Ajv from "ajv";
 
-import { InternalTypeSymbol, JsonSchema, JsonValue } from "./json-schema";
+import { InternalTypeSymbol, JsonValue, SchemaLike } from "./json-schema";
 const hiddenField = Symbol("SpecialTypeAnnotationFieldDoNotUse");
 
 type TsjsonString<T> = string & {
@@ -14,9 +14,9 @@ export const TSJSON = {
     JSON.stringify(input) as TsjsonString<T>
 };
 
-export type Validated<T extends JsonSchema> = T[typeof InternalTypeSymbol];
+export type Validated<T extends SchemaLike> = T[typeof InternalTypeSymbol];
 
-export class TsjsonParser<T extends JsonSchema> {
+export class TsjsonParser<T extends SchemaLike> {
   public readonly schema: T;
   private readonly validator: Ajv.ValidateFunction;
   constructor(schema: T) {

--- a/src/tsjson-parser.ts
+++ b/src/tsjson-parser.ts
@@ -33,7 +33,7 @@ export class TsjsonParser<T extends JsonSchema> {
   }
 
   public parse = (text: string, skipValidation = false): Validated<T> => {
-    const data = JSON.parse(text);
+    const data: unknown = JSON.parse(text);
     if (skipValidation) {
       return data;
     }


### PR DESCRIPTION
Totally rewrite so all possible schemas can be generated from a single call

createSchema(<valid JSON schema here>)

This is better because it allows arbitrary combinations of keywords that previously weren't possible.

For example, we can now specify a `type` along with an `allOf` and an `anyOf`, all at the same time, and get the final type constrained to the intersection of the constraints all of those fields impose.