### PR TITLE
Support missing fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ First, import the important stuff:
 
 `import { createSchema as S, TsjsonParser, Validator } from "ts-json-validator"`
 
-Then define a schema. `ts-json-validator` currently supports every keyword except `$ref`, `definitions`, and `dependencies`.
+Then define a schema. `ts-json-validator` currently supports every keyword, though not all of them contribute to the final derived type.
 
 Let's say we want to define a schema that accepts objects with fields "a", "b", and "c".
 A is a required string, b is an optional number, and c is an optional string that can only take on the values "B1" or "B2".
@@ -184,6 +184,7 @@ NOT SUPPORTED (❌) means you can't currently define a TsjsonSchema that include
 | additionalItems| 🔓 | Enforced with some limitations |
 | items| 🔓 |Enforced if a schema, with limitations if a list of schemas |
 | oneOf| 🔓 | currently enforced as anyOf |
+| dependencies| 🔓 | Dependency schemas are not yet enforced. |
 | $comment| 🤷 | |
 | $id| 🤷 | |
 | $schema | 🤷 | |
@@ -212,9 +213,8 @@ NOT SUPPORTED (❌) means you can't currently define a TsjsonSchema that include
 | patternProperties| ⚠️ | Can't enforce using type system |
 | propertyNames| ⚠️ | Can't enforce using type system |
 | uniqueItems| ⚠️ | Can't enforce using type system |
-| $ref| ❌ | not yet supported |
-| definitions| ❌ | not yet supported |
-| dependencies| ❌ | not yet supported |
+| $ref| ⚠️ | Still investigating enforcement. If you want a recursive type, you can use $ref, but the typescript type will not be strict. If you just want to refer to another type, don't use $ref – just assign a schema to a variable and use it in multiple places. |
+| definitions| ⚠️ | Still investigating enforcement along with $ref. |
 
 See [src/tsjson-parser.ts](./src/tsjson-parser.ts) for more details, and [the tests](./stc/tsjson.test.ts) for interactive examples.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-json-validator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Parse JSON without fear",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -176,6 +176,11 @@ interface Schema<
   If extends SchemaLike | undefined = undefined,
   Then extends SchemaLike | undefined = undefined,
   Else extends SchemaLike | undefined = undefined,
+  Definitions extends { [k: string]: SchemaLike } | undefined = undefined, // not yet enforced via refs
+  Ref extends string | undefined = undefined, // ref just gives unknown types for now. TODO: connect with definitions and get proper recursive types here.
+  Dependencies extends
+    | { [k in keyof Properties]: SchemaLike | keyof Properties[] }
+    | undefined = undefined,
   CalculatedType = ConstConstraint<Const> &
     SimpleTypeConstraint<Type> &
     EnumConstraint<Enum> &
@@ -189,7 +194,7 @@ interface Schema<
 > {
   $id?: string; // 🤷 adds no constraints, can be in any schema.
   $schema?: "http://json-schema.org/draft-07/schema#"; // 🤷 if you want to specify the schema, it's got to be draft-07 right now!
-  // $ref?: string; // not yet supported
+  $ref?: Ref; // ⚠️ not yet enforced. Going to have to try to figure out how to do this without breaking semantics.
   $comment?: string; // 🤷 adds no constraints, can be in any schema
   title?: string; // 🤷 adds no constraints, can be in any schema
   description?: string; // 🤷 adds no constraints, can be in any schema
@@ -218,12 +223,12 @@ interface Schema<
   minProperties?: Type extends "object" ? number : never; // ⚠️ only makes sense for object types
   required?: Type extends "object" ? Required : never; // 💪 only makes sense for object types
   additionalProperties?: Type extends "object" ? AdditionalProperties : never; // 💪 only makes sense for object types
-  // definitions?: // not yet supported
+  definitions?: Definitions; // ⚠️ not yet enforced
   properties?: Type extends "object" ? Properties : never; // 💪 only makes sense for object types
   patternProperties?: Type extends "object"
     ? { [k: string]: SchemaLike }
     : never; // ⚠️ only makes sense for object types
-  // dependencies?: // not yet supported
+  dependencies?: Type extends "object" ? Dependencies : never; // ⚠️ not yet enforced
   propertyNames?: Type extends "object" ? SchemaLike : never; // ⚠️ only makes sense for object types
   const?: Const; // 💪
   enum?: Enum; // 💪

--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -265,7 +265,12 @@ export const createSchema = <
   Not extends SchemaLike | undefined = undefined,
   If extends SchemaLike | undefined = undefined,
   Then extends SchemaLike | undefined = undefined,
-  Else extends SchemaLike | undefined = undefined
+  Else extends SchemaLike | undefined = undefined,
+  Definitions extends { [k: string]: SchemaLike } | undefined = undefined,
+  Ref extends string | undefined = undefined,
+  Dependencies extends
+    | { [k in keyof Properties]: SchemaLike | keyof Properties[] }
+    | undefined = undefined
 >(
   schema: Schema<
     Type,
@@ -282,7 +287,10 @@ export const createSchema = <
     Not,
     If,
     Then,
-    Else
+    Else,
+    Definitions,
+    Ref,
+    Dependencies
   >
 ) =>
   // require the InternalTypeSymbol here so we can't pass illegitimate schemas into


### PR DESCRIPTION
Add partial support for $ref, definitions, and dependencies.

In general, users of this library should avoid using $ref for now, as it doesn't look up the type in dependencies and you lose strictness. Assign schemas to variables where possible, instead. Added this now to achieve full compliance with the json schema spec; now it's possible to define any valid JSON schema (that validates to the draft-07 meta-schema) within a createSchema call!