### PR TITLE
Upgrade typescript to 3.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ts-json-validator
 
 Let JSON play nicely with Typescript.
 
-### ⚠️ Warning: This project uses some features from Typescript 3.7, which is not yet officially released.
+### ⚠️ Warning: This project requires some features from Typescript 3.7, which was just released!
 
 ## Type once, check all the time
 
@@ -40,7 +40,7 @@ First, import the important stuff:
 Then define a schema. `ts-json-validator` currently supports every keyword, though not all of them contribute to the final derived type.
 
 Let's say we want to define a schema that accepts objects with fields "a", "b", and "c".
-A is a required string, b is an optional number, and c is an optional string that can only take on the values "B1" or "B2".
+"a" is a required string, "b" is an optional number, and "c" is an optional string that can only take on the values "B1" or "B2".
 
 ```
 // Make a parser that accepts objects with fields "a", "b", and "c"
@@ -133,8 +133,9 @@ See the tests for more examples.
 
 ## Goal
 Ultimately, I hope that this can generate Typescript type/JSON schema pairs `<T, s>` such that
-    1. Any type that `s` can validate is assignable to `T`
-    2. As few types as possible that are assignable to `T` cannot be validated by `s`.
+
+1. Any type that `s` can validate is assignable to `T`
+2. As few types as possible that are assignable to `T` cannot be validated by `s`.
 
 - Step (1) is easily possible by assigning type `T` = any, but we want to narrow the type as far as possible to make this
 library actually useful.
@@ -224,6 +225,11 @@ See [src/tsjson-parser.ts](./src/tsjson-parser.ts) for more details, and [the te
 ## How does all this work?
 The object built up has the structure of a valid JSON schema with one extra magic feature: a hidden symbol that every
 schema uses to hold its own type.
+
+## Stability
+The API is subject to change until 1.0, but the runtime behavior is very straightforward and is unlikely to be any
+more dangerous than ajv by itself. If you want to use this in a production-critical environment, I recommend pinning
+an exact release until 1.0 is out.
 
 ## Contributing
 Please do!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "ts-json-validator",
-  "version": "0.0.5",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@angular/compiler": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.7.tgz",
-      "integrity": "sha512-RLXJMe+YW5a6mOj1Cxx4AkjaZX0JuerPQs4KgKx2mQXRP0LtI4+6qg2+Kds6gIJxUd1Fx9oqAflRGDPchyJaxA==",
+      "version": "8.2.13",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.13.tgz",
+      "integrity": "sha512-u2NWCvEn4SjbMvn2PG6sYcf+rR5u3aYMv3/mNQ9k+2UmCIu3yJrcuCzebjo5SdlDVqKD2vzbyMZnr8VB9OcceQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -151,9 +151,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-      "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.1.tgz",
+      "integrity": "sha512-SQ0sS7KUJDvgCI2cpZG0nJygO6002oTbhgSuw4WcocsnbxLwL5Q8I3fqbJdyBAc3uFrWZiR2JomseuxSuci3SQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -495,9 +495,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.20",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.20.tgz",
-      "integrity": "sha512-M8ebEkOpykGdLoRrmew7UowTZ1DANeeP0HiSIChl/4DGgmnSC1ntitNtkyNSXjMTsZvXuaxJrxjImEnRWNPsPw==",
+      "version": "24.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.22.tgz",
+      "integrity": "sha512-t2OvhNZnrNjlzi2i0/cxbLVM59WN15I2r1Qtb7wDv28PnV9IzrPtagFRey/S9ezdLD0zyh1XGMQIEQND2YEfrw==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"
@@ -521,6 +521,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
@@ -537,12 +543,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.0.tgz",
-      "integrity": "sha512-iCcXREU4RciLmLniwKLRPCOFVXrkF7z27XuHq5DrykpREv/mz6ztKAyLg2fdkM0hQC7659p5ZF5uStH7uzAJ/w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz",
+      "integrity": "sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.6.0",
+        "@typescript-eslint/experimental-utils": "2.6.1",
         "eslint-utils": "^1.4.2",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
@@ -550,49 +556,50 @@
       }
     },
     "@typescript-eslint/eslint-plugin-tslint": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.6.0.tgz",
-      "integrity": "sha512-xRVfz0XvzwcwIbCyXbQosm1Vwjr0tDR0t6XgEbAUTwCyP202+Q0kyu92BIc/zAbFwjmJAFlVveYtjINAY+FGIg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.6.1.tgz",
+      "integrity": "sha512-1m9cHIDKEyef22sfmTDLMXOHW2cYGsIIgx3JOFsM5mb6/WX1xJya87jphYfX4yNmMw2MqzUsph1WNgnVIIUHhA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.6.0",
+        "@typescript-eslint/experimental-utils": "2.6.1",
         "lodash.memoize": "^4.1.2"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.0.tgz",
-      "integrity": "sha512-34BAFpNOwHXeqT+AvdalLxOvcPYnCxA5JGmBAFL64RGMdP0u65rXjii7l/nwpgk5aLEE1LaqF+SsCU0/Cb64xA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz",
+      "integrity": "sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.6.0",
+        "@typescript-eslint/typescript-estree": "2.6.1",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.0.tgz",
-      "integrity": "sha512-AvLejMmkcjRTJ2KD72v565W4slSrrzUIzkReu1JN34b8JnsEsxx7S9Xx/qXEuMQas0mkdUfETr0j3zOhq2DIqQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.6.1.tgz",
+      "integrity": "sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.6.0",
-        "@typescript-eslint/typescript-estree": "2.6.0",
+        "@typescript-eslint/experimental-utils": "2.6.1",
+        "@typescript-eslint/typescript-estree": "2.6.1",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.0.tgz",
-      "integrity": "sha512-A3lSBVIdj2Gp0lFEL6in2eSPqJ33uAc3Ko+Y4brhjkxzjbzLnwBH22CwsW2sCo+iwogfIyvb56/AJri15H0u5Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz",
+      "integrity": "sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "glob": "^7.1.4",
         "is-glob": "^4.0.1",
         "lodash.unescape": "4.0.1",
-        "semver": "^6.3.0"
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
       }
     },
     "abab": {
@@ -659,9 +666,9 @@
       }
     },
     "angular-html-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-1.2.0.tgz",
-      "integrity": "sha512-sW4KZ4YOXEFTa4u69gBq+K9z5fE4llBzGP2+YqkGO9hr9GXvYtyB+3ybgVEbeoQZPEj+lFg9lQn5dfb2HRpxbQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-1.3.0.tgz",
+      "integrity": "sha512-FCLuM8ZUt30qwiV5KlW8uWL9cwlS2loOIGq8wUQFypkJ1QZqJk829yxTsvp2DvCMZ7uLwfjIaIrKV5N2+RLiSQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3"
@@ -2130,9 +2137,9 @@
       "dev": true
     },
     "flatten": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
-      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
+      "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "dev": true
     },
     "flow-parser": {
@@ -3261,9 +3268,9 @@
       }
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+      "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
       "dev": true
     },
     "is-plain-object": {
@@ -4192,14 +4199,14 @@
       "dev": true
     },
     "mem": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
+      "integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^2.1.0",
+        "p-is-promise": "^2.1.0"
       }
     },
     "merge-stream": {
@@ -4922,18 +4929,18 @@
       "dev": true
     },
     "prettier": {
-      "version": "github:prettier/prettier#56a2cd8a1b809e5f1b9f0f08b0d5bad4bbfd61d1",
+      "version": "github:prettier/prettier#d3fbdd99c21b04d901579df8146af1c1437bb774",
       "from": "github:prettier/prettier",
       "dev": true,
       "requires": {
-        "@angular/compiler": "8.2.7",
+        "@angular/compiler": "8.2.13",
         "@babel/code-frame": "7.5.5",
-        "@babel/parser": "7.6.3",
+        "@babel/parser": "7.7.0",
         "@glimmer/syntax": "0.41.0",
         "@iarna/toml": "2.2.3",
         "@typescript-eslint/typescript-estree": "2.6.0",
         "angular-estree-parser": "1.1.5",
-        "angular-html-parser": "1.2.0",
+        "angular-html-parser": "1.3.0",
         "camelcase": "5.3.1",
         "chalk": "2.4.2",
         "cjk-regex": "2.0.0",
@@ -4948,7 +4955,7 @@
         "find-parent-dir": "0.3.0",
         "find-project-root": "1.1.1",
         "flow-parser": "0.89.0",
-        "get-stream": "4.1.0",
+        "get-stream": "5.1.0",
         "globby": "6.1.0",
         "graphql": "14.5.8",
         "html-element-attributes": "2.2.0",
@@ -4962,7 +4969,7 @@
         "lines-and-columns": "1.1.6",
         "linguist-languages": "7.6.0",
         "lodash.uniqby": "4.7.0",
-        "mem": "4.3.0",
+        "mem": "5.1.1",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "n-readlines": "1.0.0",
@@ -4978,31 +4985,41 @@
         "remark-parse": "5.0.0",
         "resolve": "1.12.0",
         "semver": "6.3.0",
-        "string-width": "3.1.0",
-        "typescript": "3.7.1-rc",
+        "string-width": "4.1.0",
+        "typescript": "3.7.2",
         "unicode-regex": "3.0.0",
-        "unified": "6.1.6",
+        "unified": "8.4.1",
         "vnopts": "1.0.2",
         "yaml-unist-parser": "1.1.1"
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.3.tgz",
-          "integrity": "sha512-sUZdXlva1dt2Vw2RqbMkmfoImubO0D0gaCrNngV6Hi0DA4x3o4mlrq0tbfY0dZEUIccH8I6wQ4qgEtwcpOR6Qg==",
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.0.tgz",
+          "integrity": "sha512-GqL+Z0d7B7ADlQBMXlJgvXEbtt5qlqd1YQ5fr12hTSfh7O/vgrEIvJxU2e7aSVrEUn75zTZ6Nd0s8tthrlZnrQ==",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
+        "@typescript-eslint/typescript-estree": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.0.tgz",
+          "integrity": "sha512-A3lSBVIdj2Gp0lFEL6in2eSPqJ33uAc3Ko+Y4brhjkxzjbzLnwBH22CwsW2sCo+iwogfIyvb56/AJri15H0u5Q==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "glob": "^7.1.4",
+            "is-glob": "^4.0.1",
+            "lodash.unescape": "4.0.1",
+            "semver": "^6.3.0"
+          }
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "minimist": {
           "version": "1.2.0",
@@ -5015,17 +5032,6 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
           "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
         }
       }
     },
@@ -6125,9 +6131,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
-      "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -6202,9 +6208,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.1-rc",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.1-rc.tgz",
-      "integrity": "sha512-2rMtWppLsaPvmpXsoIAXWDBQVnJMw1ITGGSnidMuayLj9iCmMRT69ncKZw/Mk5rXfJkilApKucWQZxproALoRw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "uglify-js": {
@@ -6238,18 +6244,16 @@
       }
     },
     "unified": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
-      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
+      "integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
       "dev": true,
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-function": "^1.0.4",
-        "x-is-string": "^0.1.0"
+        "vfile": "^4.0.0"
       }
     },
     "union-value": {
@@ -6286,10 +6290,13 @@
       }
     },
     "unist-util-stringify-position": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+      "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
     },
     "unist-util-visit": {
       "version": "1.4.1",
@@ -6422,15 +6429,24 @@
       }
     },
     "vfile": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
+      "integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.4",
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "vfile-location": {
@@ -6440,12 +6456,13 @@
       "dev": true
     },
     "vfile-message": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
+      "integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
       "dev": true,
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "@types/unist": "^2.0.2",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vnopts": {
@@ -6608,18 +6625,6 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
-    },
-    "x-is-function": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/x-is-function/-/x-is-function-1.0.4.tgz",
-      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
-      "dev": true
-    },
-    "x-is-string": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
-      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-json-validator",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Parse JSON without fear",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -30,10 +30,10 @@
   "author": "Robbie Ostrow",
   "license": "MIT",
   "devDependencies": {
-    "@types/jest": "^24.0.20",
-    "@typescript-eslint/eslint-plugin": "^2.6.0",
-    "@typescript-eslint/eslint-plugin-tslint": "^2.6.0",
-    "@typescript-eslint/parser": "^2.6.0",
+    "@types/jest": "^24.0.22",
+    "@typescript-eslint/eslint-plugin": "^2.6.1",
+    "@typescript-eslint/eslint-plugin-tslint": "^2.6.1",
+    "@typescript-eslint/parser": "^2.6.1",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-config-typescript": "^3.0.0",
@@ -42,8 +42,8 @@
     "jest": "^24.9.0",
     "prettier": "github:prettier/prettier",
     "ts-jest": "^24.1.0",
-    "tslint": "^5.20.0",
-    "typescript": "^3.7.1-rc"
+    "tslint": "^5.20.1",
+    "typescript": "^3.7.2"
   },
   "peerDependencies": {
     "typescript": ">= 3.7.0"


### PR DESCRIPTION
Add a note about stability and bump typescript to 3.7.2

Typescript 3.7 is actually released so people can use this in the wild now!