### PR TITLE
improvement: change validate from an assertion function to a type guard

### DIFF
--- a/src/tsjson-parser.ts
+++ b/src/tsjson-parser.ts
@@ -25,11 +25,15 @@ export class TsjsonParser<T extends SchemaLike> {
     this.validator = ajv.compile(schema);
   }
 
-  public validate(data: unknown): asserts data is Validated<T> {
+  // call this to get the errors from the most recent validation call.
+  public getErrors = () => this.validator.errors;
+
+  public validates(data: unknown): data is Validated<T> {
     const valid = this.validator(data);
     if (!valid) {
-      throw new Error(JSON.stringify(this.validator.errors));
+      return false;
     }
+    return true;
   }
 
   public parse = (text: string, skipValidation = false): Validated<T> => {
@@ -37,7 +41,9 @@ export class TsjsonParser<T extends SchemaLike> {
     if (skipValidation) {
       return data;
     }
-    this.validate(data);
-    return data;
+    if (this.validates(data)) {
+      return data;
+    }
+    throw new Error(JSON.stringify(this.validator.errors));
   };
 }

--- a/src/tsjson.test.ts
+++ b/src/tsjson.test.ts
@@ -163,17 +163,15 @@ describe("Sanity-checks:", () => {
   });
 
   test("Ensure validate is not called if skipValidation is true", () => {
-    /* eslint-disable @typescript-eslint/unbound-method */
     const parser = new TsjsonParser(S({ type: "null" }));
-    parser.validate = jest.fn();
+    const spy = jest.spyOn(parser, "validates");
     const parsed = parser.parse(JSON.stringify(null));
     expectType<null>(parsed);
     expect(parsed).toBe(null);
-    expect(parser.validate).toBeCalledTimes(1);
+    expect(spy).toBeCalledTimes(1);
     parser.parse(JSON.stringify(null), true);
-    expect(parser.validate).toBeCalledTimes(1);
+    expect(spy).toBeCalledTimes(1);
     expect(ajv.validateSchema(parser.schema)).toBe(true);
-    /* eslint-enable @typescript-eslint/unbound-method */
   });
 
   test("SkipValidation is dangerous", () => {
@@ -181,7 +179,7 @@ describe("Sanity-checks:", () => {
     const parsed = parser.parse(JSON.stringify(SAMPLE_STRING_1), true);
     expectType<null>(parsed); // typeof parsed === null, which is wrong!
     expect(parsed).toBe(SAMPLE_STRING_1);
-    expect(() => parser.validate(parsed)).toThrow();
+    expect(parser.validates(parsed)).toBe(false);
     expect(ajv.validateSchema(parser.schema)).toBe(true);
   });
 


### PR DESCRIPTION
Usage of parser.validate is unclear because you need to assign an output type, which defeats the
purpose of this whole library (see https://github.com/microsoft/TypeScript/issues/34596 and related
issues.) This changes .validate (which throws on invalid input) to .validates, which is a type guard
that returns false on invalid input. .parse still throws on invalid input.

BREAKING CHANGE: TsjsonParser.validate renamed to TsjsonParser.validates and functionality changed
from assertion function to type guard.

This fixes the issue in the discussion of from https://github.com/ostrowr/ts-json-validator/issues/10