### PR TITLE
fix issues when attempting to export schemas 

### DIFF
--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -25,7 +25,9 @@
 // NOT SUPPORTED (❌) means you can't currently define a TsjsonSchema that includes this validation keyword :(
 
 // Symbol needed to compile a program that passes typechecking but still fails schema validation.
-export const InternalTypeSymbol = Symbol("InternalType");
+// This would be much nicer as a unique symbol but we run into issues exporting schemas
+// when we do that. Ideas welcome!
+export const InternalTypeSymbol = "#__internaltype__#";
 
 export type JsonValue =
   | { [property: string]: JsonValue }
@@ -298,7 +300,7 @@ export const createSchema = <
   {
     return {
       ...schema,
-      [InternalTypeSymbol]: {} as NonNullable<
+      "#__internaltype__#": {} as NonNullable<
         typeof schema[typeof InternalTypeSymbol]
       >
     };

--- a/src/tsjson.test.ts
+++ b/src/tsjson.test.ts
@@ -428,3 +428,11 @@ describe("Ref tests", () => {
     expect(parsed).toStrictEqual(toParse);
   });
 });
+
+// checking that we can export schemas and parsers without warnings
+export const schemaToExport = S({
+  type: "string",
+  enum: ["askjdh", "askjdh2"] as const
+});
+
+export const parserToExport = new TsjsonParser(schemaToExport);


### PR DESCRIPTION
If this library is used in projects with `declaration: true`, it was impossible to export a schema.

This was because the type wasn't explicitly specified in createSchema, and it seems impossible to do so while using a unique symbol.

This fixes the import issue at the cost of using a string instead of a unique symbol. I'd prefer to use a symbol.