### PR TITLE
fix(additionalProperties): treat additionalProperties as optional

### DIFF
--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -110,7 +110,7 @@ type PropertiesConstraint<
 type AdditionalPropertiesConstraint<
   AdditionalProperties extends SchemaLike | undefined
 > = AdditionalProperties extends SchemaLike
-  ? { [k: string]: AdditionalProperties[typeof InternalTypeSymbol] }
+  ? Partial<{ [k: string]: AdditionalProperties[typeof InternalTypeSymbol] }>
   : unknown;
 
 // if items is a schema, then every element conforms to it.

--- a/src/tsjson.test.ts
+++ b/src/tsjson.test.ts
@@ -303,7 +303,7 @@ describe("More involved tests with objects", () => {
 
     expectType<object>(parsed.a);
     expectType<object | undefined>(parsed.d);
-    expectType<number>(parsed.anotherProp);
+    expectType<number | undefined>(parsed.anotherProp);
 
     const toFail = {};
     expect(() => parser.parse(JSON.stringify(toFail))).toThrow();
@@ -328,7 +328,7 @@ describe("additionalProperties", () => {
         })
       );
       expectType<{}>(parsed);
-      expectType<never>(parsed.someAdditionalProperty);
+      expectType<undefined>(parsed.someAdditionalProperty);
       expect(parsed).toStrictEqual({});
 
       expectType<Validated<typeof schema>>({});
@@ -356,14 +356,14 @@ describe("additionalProperties", () => {
       expectType<string | undefined>(
         parsedWithOptionalProperty.optionalProperty
       );
-      expectType<never>(parsedWithOptionalProperty.someAdditionalProperty);
+      expectType<undefined>(parsedWithOptionalProperty.someAdditionalProperty);
       expect(parsedWithOptionalProperty).toEqual({
         optionalProperty: "some value"
       });
 
       const parsedWithNoProperties = parser.parse(JSON.stringify({}));
       expectType<{}>(parsedWithNoProperties);
-      expectType<never>(parsedWithNoProperties.someAdditionalProperty);
+      expectType<undefined>(parsedWithNoProperties.someAdditionalProperty);
       expect(parsedWithNoProperties).toEqual({});
 
       expectType<Validated<typeof schema>>({});
@@ -395,7 +395,7 @@ describe("additionalProperties", () => {
         })
       );
       expectType<string>(parsedWithOptionalProperty.requiredProperty);
-      expectType<never>(parsedWithOptionalProperty.someAdditionalProperty);
+      expectType<undefined>(parsedWithOptionalProperty.someAdditionalProperty);
       expect(parsedWithOptionalProperty).toEqual({
         requiredProperty: "some value"
       });
@@ -542,7 +542,7 @@ describe("additionalProperties", () => {
           someAdditionalProperty: 10
         })
       );
-      expectType<number>(parsed.someAdditionalProperty);
+      expectType<number | undefined>(parsed.someAdditionalProperty);
       expect(parsed).toStrictEqual({
         someAdditionalProperty: 10
       });
@@ -576,7 +576,9 @@ describe("additionalProperties", () => {
       expectType<string | undefined>(
         parsedWithOptionalProperty.optionalProperty
       );
-      expectType<number>(parsedWithOptionalProperty.someAdditionalProperty);
+      expectType<number | undefined>(
+        parsedWithOptionalProperty.someAdditionalProperty
+      );
       expect(parsedWithOptionalProperty).toEqual({
         optionalProperty: "some value",
         someAdditionalProperty: 10
@@ -585,7 +587,9 @@ describe("additionalProperties", () => {
       const parsedWithNoProperties = parser.parse(JSON.stringify({}));
       expectType<{}>(parsedWithNoProperties);
       expectType<string | undefined>(parsedWithNoProperties.optionalProperty);
-      expectType<number>(parsedWithNoProperties.someAdditionalProperty);
+      expectType<number | undefined>(
+        parsedWithNoProperties.someAdditionalProperty
+      );
       expect(parsedWithNoProperties).toEqual({});
 
       expectType<Validated<typeof schema>>({});
@@ -626,7 +630,9 @@ describe("additionalProperties", () => {
         })
       );
       expectType<string>(parsedWithOptionalProperty.requiredProperty);
-      expectType<number>(parsedWithOptionalProperty.someAdditionalProperty);
+      expectType<number | undefined>(
+        parsedWithOptionalProperty.someAdditionalProperty
+      );
       expect(parsedWithOptionalProperty).toEqual({
         requiredProperty: "some value",
         someAdditionalProperty: 10


### PR DESCRIPTION
I'm not 100% sure about this change, but it occurred to me while I was working on #30.

Should `additionalProperties` be treated as optional (as in, with a `Partial<...>`)? Because after parsing an object, you can't actually be sure in the type system whether `parsedObject.someAdditionalProperty` is defined or not.

One problem I can think of is that it softens the restriction when using `additionalProperties: S(false)`, because it'll enforce `Partial<{ [k: string]: never }>` instead of the stricter `{ [k: string]: never }`.

Don't worry about a bunch of extra noise from me :) This will be my last PR for a little while and I thought I'd just put up this PR directly because it came up while working on #30 and I had the code written already.